### PR TITLE
Authentication Page 완성

### DIFF
--- a/millionaire/public/data/authentication.json
+++ b/millionaire/public/data/authentication.json
@@ -1,0 +1,28 @@
+{
+	"task": [
+		{
+			"task_id": 1,
+			"member_name": "seoson",
+			"content": "세후 1억 프로젝트 완성하기",
+			"status": "pend",
+			"created_time": "2024-09-14:00:00:00",
+			"updated_time": "2024-09-14:00:00:10"
+		},
+		{
+			"task_id": 2,
+			"member_name": "seoson",
+			"content": "세후 1억 프로젝트 완성하기",
+			"status": "pend",
+			"created_time": "2024-09-14:00:00:00",
+			"updated_time": "2024-09-14:00:00:10"
+		},
+		{
+			"task_id": 3,
+			"member_name": "seoson",
+			"content": "세후 5000만원 프로젝트 완성하기",
+			"status": "pend",
+			"created_time": "2024-09-14:00:00:00",
+			"updated_time": "2024-09-14:00:00:10"
+		}
+	]
+}

--- a/millionaire/public/data/authentication.json
+++ b/millionaire/public/data/authentication.json
@@ -1,28 +1,28 @@
 {
-	"task": [
+	"tasks": [
 		{
 			"task_id": 1,
-			"member_name": "seoson",
+			"memberName": "seoson",
 			"content": "세후 1억 프로젝트 완성하기",
 			"status": "pend",
-			"created_time": "2024-09-14:00:00:00",
-			"updated_time": "2024-09-14:00:00:10"
+			"createdTime": "2024-09-14:00:00:00",
+			"updatedTime": "2024-09-14:00:00:10"
 		},
 		{
 			"task_id": 2,
-			"member_name": "seoson",
+			"memberName": "seoson",
 			"content": "세후 1억 프로젝트 완성하기",
 			"status": "pend",
-			"created_time": "2024-09-14:00:00:00",
-			"updated_time": "2024-09-14:00:00:10"
+			"createdTime": "2024-09-14:00:00:00",
+			"updatedTime": "2024-09-14:00:00:10"
 		},
 		{
 			"task_id": 3,
-			"member_name": "seoson",
+			"memberName": "seoson",
 			"content": "세후 5000만원 프로젝트 완성하기",
 			"status": "pend",
-			"created_time": "2024-09-14:00:00:00",
-			"updated_time": "2024-09-14:00:00:10"
+			"createdTime": "2024-09-14:00:00:00",
+			"updatedTime": "2024-09-14:00:00:10"
 		}
 	]
 }

--- a/millionaire/src/App.jsx
+++ b/millionaire/src/App.jsx
@@ -1,6 +1,7 @@
 import "./App.css";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Main from "./app/Main.jsx";
+import Admin from "./app/Admin.jsx";
 
 function App() {
 	return (
@@ -8,7 +9,7 @@ function App() {
 			<Routes>
 				<Route path="/" element={<Main />} />
 				{/* <Route path="/login" element={<Login />} /> */}
-				{/* <Route path="/admin" element={<Admin />} /> */}
+				<Route path="/admin" element={<Admin />} />
 			</Routes>
 		</BrowserRouter>
 	);

--- a/millionaire/src/apis/get.js
+++ b/millionaire/src/apis/get.js
@@ -1,0 +1,15 @@
+import BASE_URL from "../constants/URL";
+
+const getAPI= async(path) =>{
+    const response = await fetch(`${BASE_URL}/${path}`, {
+        headers: {
+            "Accept": "application/json",
+            "ngrok-skip-browser-warning": true,
+        },
+        method: "GET",
+    });
+    // const response = await fetch("../../public/data/authentication.json");
+    return response.json();
+}
+
+export {getAPI};

--- a/millionaire/src/app/Admin.jsx
+++ b/millionaire/src/app/Admin.jsx
@@ -1,0 +1,48 @@
+import Authentication from "../components/Authentication";
+import MemberManage from "../components/MemberManage";
+import DashBoard from "../components/DashBoard";
+import Notice from "../components/Notice";
+import {useState} from 'react';
+
+export default function Admin() {
+	const [page, setPage] = useState("AUTH");
+	let adminBody = null;
+
+	if (page === "AUTH"){
+		adminBody = Authentication();
+	} else if (page === "MEMBER") {
+		adminBody = MemberManage();
+	} else if (page === "DASH") {
+		adminBody = DashBoard();
+	} else if (page === "NOTICE") {
+		adminBody = Notice();
+	}
+	return (
+		<div className="flex text-orange-400">
+		<div className="flex-none w-[23%] mt-[20px] ml-[20px]">
+			<h1 className="mb-[50px] text-[36px]">세후1억 해적단</h1>
+			<nav>
+				<ul className="text-[20px]">
+					<li onClick={event=>{
+						event.preventDefault();
+						setPage("AUTH");
+					}}>Authentication</li>
+					<li onClick={event=>{
+						event.preventDefault();
+						setPage("MEMBER");
+					}}>Member Management</li>
+					<li onClick={event=>{
+						event.preventDefault();
+						setPage("DASH");
+					}}>Dash Board</li>
+					<li onClick={event=>{
+						event.preventDefault();
+						setPage("NOTICE");
+					}}>Notice Board</li>
+				</ul>
+			</nav>
+		</div>
+		{adminBody}
+		</div>
+	);
+}

--- a/millionaire/src/app/Admin.jsx
+++ b/millionaire/src/app/Admin.jsx
@@ -17,7 +17,7 @@ export default function Admin() {
 	const AdminBody = PAGES[page];
 
 	return (
-		<div className="flex text-orange-400">
+		<div className="flex text-gray-300">
 			<Sidebar setPage={setPage} />
 			<AdminBody />
 		</div>

--- a/millionaire/src/app/Admin.jsx
+++ b/millionaire/src/app/Admin.jsx
@@ -1,48 +1,25 @@
+import { useState } from "react";
 import Authentication from "../components/Authentication";
 import MemberManage from "../components/MemberManage";
 import DashBoard from "../components/DashBoard";
 import Notice from "../components/Notice";
-import {useState} from 'react';
+import Sidebar from "../components/Sidebar";
+
+const PAGES = {
+	AUTH: Authentication,
+	MEMBER: MemberManage,
+	DASH: DashBoard,
+	NOTICE: Notice,
+};
 
 export default function Admin() {
 	const [page, setPage] = useState("AUTH");
-	let adminBody = null;
+	const AdminBody = PAGES[page];
 
-	if (page === "AUTH"){
-		adminBody = Authentication();
-	} else if (page === "MEMBER") {
-		adminBody = MemberManage();
-	} else if (page === "DASH") {
-		adminBody = DashBoard();
-	} else if (page === "NOTICE") {
-		adminBody = Notice();
-	}
 	return (
 		<div className="flex text-orange-400">
-		<div className="flex-none w-[23%] mt-[20px] ml-[20px]">
-			<h1 className="mb-[50px] text-[36px]">세후1억 해적단</h1>
-			<nav>
-				<ul className="text-[20px]">
-					<li onClick={event=>{
-						event.preventDefault();
-						setPage("AUTH");
-					}}>Authentication</li>
-					<li onClick={event=>{
-						event.preventDefault();
-						setPage("MEMBER");
-					}}>Member Management</li>
-					<li onClick={event=>{
-						event.preventDefault();
-						setPage("DASH");
-					}}>Dash Board</li>
-					<li onClick={event=>{
-						event.preventDefault();
-						setPage("NOTICE");
-					}}>Notice Board</li>
-				</ul>
-			</nav>
-		</div>
-		{adminBody}
+			<Sidebar setPage={setPage} />
+			<AdminBody />
 		</div>
 	);
 }

--- a/millionaire/src/app/Main.jsx
+++ b/millionaire/src/app/Main.jsx
@@ -1,3 +1,8 @@
 export default function Main() {
-	return <h1 className="text-orange-400 text-[50px] ">Main</h1>;
+	return (
+		<div className="text-orange-400 text-[50px] ">
+			<h1>Main</h1>
+			<a href="/admin">Admin</a>
+		</div>
+	);
 }

--- a/millionaire/src/components/AdminBody.jsx
+++ b/millionaire/src/components/AdminBody.jsx
@@ -1,0 +1,10 @@
+const AdminBody = ({title, children})=>{
+	return (
+		<div className="w-[65%] mt-[20px]">
+			<h1 className="mb-[30px] mt-[10px] text-[40px]">{title}</h1>
+			{children}
+		</div>
+	)
+}
+
+export default AdminBody;

--- a/millionaire/src/components/AdminContentBlock.jsx
+++ b/millionaire/src/components/AdminContentBlock.jsx
@@ -1,0 +1,13 @@
+const AdminContentBlock = ({title, contents, className}) =>{
+	return (
+		<div className={className}>
+		<div className="mb-[50px]">
+				<h1 className="text-[25px]">{title}</h1>
+				<hr className="mb-[5px]"></hr>
+				{contents()}
+		</div>
+		</div>
+	)
+}
+
+export default AdminContentBlock;

--- a/millionaire/src/components/AppealModalContent.jsx
+++ b/millionaire/src/components/AppealModalContent.jsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from "react";
+
+const AppealModalContent = (id, title) => {
+    const [data, setData] = useState([]);
+
+	useEffect(() => {
+		const fetchData = async () => {
+			try {
+				const response = await fetch(`${BASE_URL}/verification/${id}`, {
+					headers: {
+						"Accept": "application/json",
+						"ngrok-skip-browser-warning": true,
+					},
+					method: "GET",
+				});
+				const res = await response.json();
+				console.log(res);
+				setData(res);
+			} catch (error) {
+				console.error(error);
+			}
+		};
+		fetchData();
+	}, []);
+    return (
+        <div>
+            <h3>{title}</h3>
+            <div>{data.createTime}</div>
+            <div>{data.updateTime}</div>
+            <hr></hr>
+            <div className="">
+                <div>{data.content}</div>
+                {data.base64_images.map(
+					(item) =>(
+						<image src={item}/>
+					),
+				)}
+            </div>
+        </div>
+    )
+}
+
+
+export default AppealModalContent;

--- a/millionaire/src/components/Authentication.jsx
+++ b/millionaire/src/components/Authentication.jsx
@@ -1,0 +1,67 @@
+export default function Authentication() {
+	return (
+		<div className="flex-none w-[65%] mt-[20px]">
+			<h1 className="mb-[10px] text-[40px]">Authentication</h1>
+			<div className="mb-[50px] w-[100%]">
+				<h1 className="text-[25px]">Task</h1>
+				<hr className="mb-[5px]"></hr>
+				<ul className="text-[20px]">
+					<li className="flex">
+						<div className="w-[35%]">다이렉트x 완성하기</div>
+						<div className="w-[20%]">hyuim</div>
+						<div className="w-[33%]">2024.09.03 23:02</div>
+						<div className="w-[10%] text-center">✅ ❎</div>
+					</li>
+					<li className="flex">
+						<div className="w-[35%]">스프링 마스터</div>
+						<div className="w-[20%]">soohlee</div>
+						<div className="w-[33%]">2024.09.03 23:02</div>
+						<div className="w-[10%] text-center">✅ ❎</div>
+					</li>
+					<li className="flex">
+						<div className="w-[35%]">Webserv 완성하기</div>
+						<div className="w-[20%]">sungmiki</div>
+						<div className="w-[33%]">2024.09.03 23:02</div>
+						<div className="w-[10%] text-center">✅ ❎</div>
+					</li>
+					<li className="flex">
+						<div className="w-[35%]">세후1억 프로젝트</div>
+						<div className="w-[20%]">jonhan</div>
+						<div className="w-[33%]">2024.09.03 23:02</div>
+						<div className="w-[10%] text-center">✅ ❎</div>
+					</li>
+					<li className="flex">
+						<div className="w-[35%]">클러스터 10시간 있기</div>
+						<div className="w-[20%]">junssong</div>
+						<div className="w-[33%]">2024.09.03 23:02</div>
+						<div className="w-[10%] text-center">✅ ❎</div>
+					</li>
+				</ul>
+			</div>
+			<div className="w-[100%]">
+				<h1 className="text-[25px]">Appeels</h1>
+				<hr className="mb-[5px]"></hr>
+				<ul className="text-[20px]">
+					<li className="flex">
+						<div className="w-[35%]">토익 단어 100개 외우기</div>
+						<div className="w-[20%]">younghyle</div>
+						<div className="w-[33%]">2024.09.03 23:02</div>
+						<div className="w-[10%] text-center">✅ ❎</div>
+					</li>
+					<li className="flex">
+						<div className="w-[35%]">편입수학 편미분</div>
+						<div className="w-[20%]">phan</div>
+						<div className="w-[33%]">2024.09.03 23:02</div>
+						<div className="w-[10%] text-center">✅ ❎</div>
+					</li>
+					<li className="flex">
+						<div className="w-[35%]">주지스 마스터</div>
+						<div className="w-[20%]">hcho2</div>
+						<div className="w-[33%]">2024.09.03 23:02</div>
+						<div className="w-[10%] text-center">✅ ❎</div>
+					</li>
+				</ul>
+			</div>
+		</div>
+	)
+}

--- a/millionaire/src/components/Authentication.jsx
+++ b/millionaire/src/components/Authentication.jsx
@@ -1,42 +1,47 @@
-export default function Authentication() {
+import { useEffect, useState } from "react";
+
+const Authentication = () => {
+	const [data, setData] = useState([]);
+	useEffect(() => {
+		const fetchData = async () => {
+			try {
+				const response = await fetch("../data/authentication.json", {
+					headers: {
+						"Content-Type": "application/json",
+					},
+				});
+				const res = await response.json();
+				setData(res.task);
+			} catch (error) {
+				console.error(error);
+			}
+		};
+		fetchData();
+	}, []);
+
+	const renderData = () => {
+		return data.map(
+			(item) =>
+				item.status === "pend" && (
+					<li key={item.id} className="flex">
+						<div className="w-[35%] mr-[1%] whitespace-nowrap overflow-hidden text-ellipsis">
+							{item.content}
+						</div>
+						<div className="w-[20%]">{item.member_name}</div>
+						<div className="w-[33%]">{item.created_time}</div>
+						<div className="w-[10%] text-center">✅ ❎</div>
+					</li>
+				),
+		);
+	};
+
 	return (
-		<div className="flex-none w-[65%] mt-[20px]">
+		<div className="w-[65%] mt-[20px]">
 			<h1 className="mb-[10px] text-[40px]">Authentication</h1>
 			<div className="mb-[50px] w-[100%]">
 				<h1 className="text-[25px]">Task</h1>
 				<hr className="mb-[5px]"></hr>
-				<ul className="text-[20px]">
-					<li className="flex">
-						<div className="w-[35%]">다이렉트x 완성하기</div>
-						<div className="w-[20%]">hyuim</div>
-						<div className="w-[33%]">2024.09.03 23:02</div>
-						<div className="w-[10%] text-center">✅ ❎</div>
-					</li>
-					<li className="flex">
-						<div className="w-[35%]">스프링 마스터</div>
-						<div className="w-[20%]">soohlee</div>
-						<div className="w-[33%]">2024.09.03 23:02</div>
-						<div className="w-[10%] text-center">✅ ❎</div>
-					</li>
-					<li className="flex">
-						<div className="w-[35%]">Webserv 완성하기</div>
-						<div className="w-[20%]">sungmiki</div>
-						<div className="w-[33%]">2024.09.03 23:02</div>
-						<div className="w-[10%] text-center">✅ ❎</div>
-					</li>
-					<li className="flex">
-						<div className="w-[35%]">세후1억 프로젝트</div>
-						<div className="w-[20%]">jonhan</div>
-						<div className="w-[33%]">2024.09.03 23:02</div>
-						<div className="w-[10%] text-center">✅ ❎</div>
-					</li>
-					<li className="flex">
-						<div className="w-[35%]">클러스터 10시간 있기</div>
-						<div className="w-[20%]">junssong</div>
-						<div className="w-[33%]">2024.09.03 23:02</div>
-						<div className="w-[10%] text-center">✅ ❎</div>
-					</li>
-				</ul>
+				<ul className="text-[20px]">{renderData()}</ul>
 			</div>
 			<div className="w-[100%]">
 				<h1 className="text-[25px]">Appeels</h1>
@@ -63,5 +68,7 @@ export default function Authentication() {
 				</ul>
 			</div>
 		</div>
-	)
-}
+	);
+};
+
+export default Authentication;

--- a/millionaire/src/components/Authentication.jsx
+++ b/millionaire/src/components/Authentication.jsx
@@ -11,8 +11,7 @@ const Authentication = () => {
 	useEffect(() => {
 		const fetchData = async () => {
 			try {
-				const response = await fetch(`${BASE_URL}/task/01`, {
-
+				const response = await fetch(`${BASE_URL}/task/01`, {	
 					method: "GET"
 				});
 				const res = await response.json();

--- a/millionaire/src/components/Authentication.jsx
+++ b/millionaire/src/components/Authentication.jsx
@@ -1,75 +1,253 @@
 import { useEffect, useState } from "react";
 import AdminContentBlock from "./AdminContentBlock.jsx";
 import AdminBody from "./AdminBody.jsx";
+import { getAPI } from "../apis/get.js";
+import Modal from "./Modal.jsx";
+import Li from "./Li.jsx";
 import BASE_URL from "../constants/URL.js";
 
 const Authentication = () => {
-	const [data, setData] = useState([]);
-	// const [appeals, setAppeals] = useState([]);
-	// setAppeals(res.appeals);
+	const [pend, setPend] = useState([]);
+	const [appeal, setAppeal] = useState([]);
+	const [pendModalContent, setPendModalContent] = useState(null);
+	const [appealModalContent, setAppealModalContent] = useState(null);
+	const [isOpen, setIsOpen] = useState(false);
 
 	useEffect(() => {
-		const fetchData = async () => {
-			try {
-				const response = await fetch(`${BASE_URL}/task/pend/1`, {
-					headers: {
-						"Accept": "application/json",
-						"ngrok-skip-browser-warning": true,
-					},
-					method: "GET",
-				});
-				const res = await response.json();
-				console.log(res);
-				setData(res.tasks);
-			} catch (error) {
-				console.error(error);
-			}
-		};
-		fetchData();
+		fetchPend();
 	}, []);
+	
+	const fetchPend = async () => {
+		try {
+			const data = await getAPI('task/pend/1');
+			setPend(data.tasks);
+		} catch (error) {
+			console.error(error);
+		}
+	};
+	
+	const pendYes = (taskId) => {
+		try {
+            const response = fetch(`${BASE_URL}/task/status`, {
+                headers: {
+                    "Accept": "application/json",
+					"Content-Type": "application/json",
+                    "ngrok-skip-browser-warning": true,
+                },
+                method: "PATCH",
+				body:JSON.stringify({
+					"taskId": taskId, // {} 안에 taskId만 전달
+					"status": "accept"
+				}),
+            });
+			const tmp = [];
+			for (let i = 0; i < pend.length; i++) {
+				if (pend[i].taskId !== taskId)
+					tmp.push(pend[i]);
+				setPend(tmp);
+			}
+            console.log(response);
+        } catch (error) {
+            console.error(error);
+        }
+	}
+
+	const pendNo = (taskId) => {
+		try {
+            const response = fetch(`${BASE_URL}/task/status`, {
+                headers: {
+					"Accept": "application/json",
+                    "Content-Type": "application/json",
+                    "ngrok-skip-browser-warning": true,
+                },
+                method: "PATCH",
+				body:JSON.stringify({
+					"taskId" : taskId,
+					"status" : "deny"
+				}),
+            });
+            console.log(response);
+			if (response.status === 200){
+				const tmp = [];
+				for (let i = 0; i < pend.length; i++) {
+					if (pend[i].taskId !== taskId)
+						tmp.push(pend[i]);
+				}
+				setPend(tmp);
+			}
+        } catch (error) {
+            console.error(error);
+        }
+	}
 
 	const renderPendings = () => {
 		return (
-			<ul className="text-[20px]">
-				{data.map(
-					(item) =>
-						item.status === "pend" && (
-							<li key={item.id} className="flex hover:text-orange-400">
-								<div className="w-[35%] mr-[1%] whitespace-nowrap overflow-hidden text-ellipsis cursor-pointer">
-									{item.content}
-								</div>
-								<div className="w-[20%]">{item.memberName}</div>
-								<div className="w-[33%]">{item.createdTime}</div>
-								<div className="w-[10%] text-center">✅ ❎</div>
-							</li>
-						),
+			<ul>
+				{pend.map(
+					(item) =>(
+						<Li key={item.taskId} item={item} openModal={fetchPendModal} yes={pendYes} no={pendNo} id={item.taskId}/>
+					),
 				)}
 			</ul>
 		);
 	};
-	// const renderAppeals = () => {
-	// 	return (
-	// 		<ul className="text-[20px]">
-	// 			{appeals.map(
-	// 			(item) =>(
-	// 					<li key={item.id} className="flex hover:text-orange-400">
-	// 						<div className="w-[35%] mr-[1%] whitespace-nowrap overflow-hidden text-ellipsis cursor-pointer">
-	// 							{item.content}
-	// 						</div>
-	// 						<div className="w-[20%]">{item.member_name}</div>
-	// 						<div className="w-[33%]">{item.created_at}</div>
-	// 						<div className="w-[10%] text-center">✅ ❎</div>
-	// 					</li>
-	// 				),
-	// 			)}
-	// 		</ul>
-	// 	);
-	// };
 
+	useEffect(() => {
+		fetchAppeal();
+	}, []);
+
+	const fetchAppeal = async () => {
+		try {
+			const data = await getAPI('appeal/1');
+			setAppeal(data.appeals);
+		} catch (error) {
+			console.error(error);
+		}
+	};
+
+	const appealYes = (appealId) => {
+		try {
+            const response = fetch(`${BASE_URL}/appeal`, {
+                headers: {
+                    "Accept": "application/json",
+					"Content-Type": "application/json",
+                    "ngrok-skip-browser-warning": true,
+                },
+                method: "PATCH",
+				body:JSON.stringify({
+					"appealId" : appealId,
+					"status" : "accept"
+				}),
+            });
+            console.log(response);
+			const tmp = [];
+			for (let i = 0; i < appeal.length; i++) {
+				if (appeal[i].appealId !== appealId)
+					tmp.push(appeal[i]);
+				setAppeal(tmp);
+			}
+        } catch (error) {
+            console.error(error);
+        }
+	}
+
+	const appealNo = (appealId) => {
+		try {
+            const response = fetch(`${BASE_URL}/appeal`, {
+                headers: {
+                    "Accept": "application/json",
+					"Content-Type": "application/json",
+                    "ngrok-skip-browser-warning": true,
+                },
+                method: "PATCH",
+				body:JSON.stringify({
+					"appealId" : appealId,
+					"status" : "deny"
+				}),
+            });
+            console.log(response);
+			const tmp = [];
+			for (let i = 0; i < appeal.length; i++) {
+				if (appeal[i].appealId !== appealId)
+					tmp.push(appeal[i]);
+				setAppeal(tmp);
+			}
+        } catch (error) {
+            console.error(error);
+        }
+	}
+
+	const renderAppeals = () => {
+		return (
+			<ul className="text-[17px]">
+				{appeal.map(
+					(item) =>(
+						<Li key={item.taskId} item={item} openModal={fetchAppealModal} yes={appealYes} no={appealNo} id={item.appealId}/>
+					),
+				)}
+			</ul>
+		);
+	};
+	
+	useEffect(()=>{
+		if (pendModalContent !== null)
+			setIsOpen(true);
+	},[pendModalContent])
+
+	const fetchPendModal = async (taskId, content, time) =>{
+		try {
+			const data = await getAPI(`verification/${taskId}`);
+			console.log(data);
+			setPendModalContent(
+				<div className="text-black">
+					<h1 className="mb-[10px] text-[20px]">{content}</h1>
+					<div className="text-[12px]">created at: {data.createdTime}</div>
+					<div className="text-[12px]">updated at: {data.updatedTime}</div>
+					<hr className="mt-[10px] mb-[10px]"></hr>
+					<div className="mt-[5px] text-black border border-black rounded-lg p-[5px] overflow-auto h-[400px]">
+						<div className="mb-[10px]">{data.content}</div>
+						{data.base64Images.map(
+							(item) =>(
+								<img src={`data:image/png;base64,${item}`}/>
+							),
+						)}
+					</div>
+				</div>
+			);
+		} catch (error) {
+			console.error(error);
+		}
+	}
+	
+	useEffect(()=>{
+		if (appealModalContent !== null)
+			setIsOpen(true);
+	},[appealModalContent])
+	
+	const fetchAppealModal = async (taskId, content, time) =>{
+		try {
+			const verifcation = await getAPI(`verification/${taskId}`);
+			const task = await getAPI(`task/${taskId}`);
+			console.log(verifcation);
+			setAppealModalContent(
+				<div className="text-black">
+					<h1 className="mb-[10px] text-[20px]">이의제기내용: {content}</h1>
+					<div className="text-[12px]">created at: {time}</div>
+					<div className="text-[12px]">{task.memberName}</div>
+					<div className="mt-[5px] text-black border border-black rounded-lg p-[5px] overflow-auto h-[400px]">
+						<h1 className="mb-[10px] text-[20px]">{verifcation.title}</h1>
+						<div className="text-[12px]">created at: {task.createdTime}</div>
+						<div className="text-[12px]">updated at: {task.updatedTime}</div>
+						<div className="text-[12px]">verificated at: {verifcation.updatedTime}</div>
+						<div className="text-[12px]">due date: {task.dueDate}</div>
+						<hr className="mt-[10px] mb-[10px]"></hr>
+						<div>
+							<div className="mb-[10px]">{verifcation.content}</div>
+							{verifcation.base64Images.map(
+								(item) =>(
+									<img src={`data:image/png;base64,${item}`}/>
+								),
+							)}
+						</div>
+					</div>
+				</div>
+			);
+		} catch (error) {
+			console.error(error);
+		}
+	}
+	
+	const closeModal = () => {
+		setIsOpen(false);
+		setPendModalContent(null);
+		setAppealModalContent(null);
+	}
+	
 	return (
 		<AdminBody title={"Authentication"}>
-			<AdminContentBlock title={"Pendings"} contents={renderPendings} />
-			{/* <AdminContentBlock title={"Appeals"} contents={renderAppeals}/> */}
+			<AdminContentBlock title={"인증 대기"} contents={renderPendings} />
+			<AdminContentBlock title={"이의 제기"} contents={renderAppeals}/>
+			<Modal isOpen={isOpen} onClose={closeModal}>{pendModalContent}{appealModalContent}</Modal>
 		</AdminBody>
 	);
 };

--- a/millionaire/src/components/Authentication.jsx
+++ b/millionaire/src/components/Authentication.jsx
@@ -1,14 +1,19 @@
 import { useEffect, useState } from "react";
+import AdminContentBlock from "./AdminContentBlock";
+import AdminBody from "./AdminBody";
+import BASE_URL from "../constants/URL";
 
 const Authentication = () => {
 	const [data, setData] = useState([]);
+	// const [appeals, setAppeals] = useState([]);
+	// setAppeals(res.appeals);
+
 	useEffect(() => {
 		const fetchData = async () => {
 			try {
-				const response = await fetch("../data/authentication.json", {
-					headers: {
-						"Content-Type": "application/json",
-					},
+				const response = await fetch(`${BASE_URL}/task/01`, {
+
+					method: "GET"
 				});
 				const res = await response.json();
 				setData(res.task);
@@ -18,56 +23,50 @@ const Authentication = () => {
 		};
 		fetchData();
 	}, []);
-
-	const renderData = () => {
-		return data.map(
-			(item) =>
-				item.status === "pend" && (
-					<li key={item.id} className="flex">
-						<div className="w-[35%] mr-[1%] whitespace-nowrap overflow-hidden text-ellipsis">
-							{item.content}
-						</div>
-						<div className="w-[20%]">{item.member_name}</div>
-						<div className="w-[33%]">{item.created_time}</div>
-						<div className="w-[10%] text-center">✅ ❎</div>
-					</li>
+	
+	const renderPendings = () => {
+		return (
+			<ul className="text-[20px]">{
+				data.map(
+				(item) =>
+					item.status === "pend" && (
+						<li key={item.id} className="flex hover:text-orange-400">
+							<div className="w-[35%] mr-[1%] whitespace-nowrap overflow-hidden text-ellipsis cursor-pointer">
+								{item.content}
+							</div>
+							<div className="w-[20%]">{item.member_name}</div>
+							<div className="w-[33%]">{item.created_time}</div>
+							<div className="w-[10%] text-center">✅ ❎</div>
+						</li>
 				),
-		);
+				)}
+			</ul>
+		)
 	};
+	// const renderAppeals = () => {
+	// 	return (
+	// 		<ul className="text-[20px]">
+	// 			{appeals.map(
+	// 			(item) =>(
+	// 					<li key={item.id} className="flex hover:text-orange-400">
+	// 						<div className="w-[35%] mr-[1%] whitespace-nowrap overflow-hidden text-ellipsis cursor-pointer">
+	// 							{item.content}
+	// 						</div>
+	// 						<div className="w-[20%]">{item.member_name}</div>
+	// 						<div className="w-[33%]">{item.created_at}</div>
+	// 						<div className="w-[10%] text-center">✅ ❎</div>
+	// 					</li>
+	// 				),
+	// 			)}
+	// 		</ul>
+	// 	);
+	// };
 
 	return (
-		<div className="w-[65%] mt-[20px]">
-			<h1 className="mb-[10px] text-[40px]">Authentication</h1>
-			<div className="mb-[50px] w-[100%]">
-				<h1 className="text-[25px]">Task</h1>
-				<hr className="mb-[5px]"></hr>
-				<ul className="text-[20px]">{renderData()}</ul>
-			</div>
-			<div className="w-[100%]">
-				<h1 className="text-[25px]">Appeels</h1>
-				<hr className="mb-[5px]"></hr>
-				<ul className="text-[20px]">
-					<li className="flex">
-						<div className="w-[35%]">토익 단어 100개 외우기</div>
-						<div className="w-[20%]">younghyle</div>
-						<div className="w-[33%]">2024.09.03 23:02</div>
-						<div className="w-[10%] text-center">✅ ❎</div>
-					</li>
-					<li className="flex">
-						<div className="w-[35%]">편입수학 편미분</div>
-						<div className="w-[20%]">phan</div>
-						<div className="w-[33%]">2024.09.03 23:02</div>
-						<div className="w-[10%] text-center">✅ ❎</div>
-					</li>
-					<li className="flex">
-						<div className="w-[35%]">주지스 마스터</div>
-						<div className="w-[20%]">hcho2</div>
-						<div className="w-[33%]">2024.09.03 23:02</div>
-						<div className="w-[10%] text-center">✅ ❎</div>
-					</li>
-				</ul>
-			</div>
-		</div>
+		<AdminBody title={"Authentication"}>
+			<AdminContentBlock title={"Pendings"} contents={renderPendings}/>
+			{/* <AdminContentBlock title={"Appeals"} contents={renderAppeals}/> */}
+		</AdminBody>
 	);
 };
 

--- a/millionaire/src/components/Authentication.jsx
+++ b/millionaire/src/components/Authentication.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
-import AdminContentBlock from "./AdminContentBlock";
-import AdminBody from "./AdminBody";
-import BASE_URL from "../constants/URL";
+import AdminContentBlock from "./AdminContentBlock.jsx";
+import AdminBody from "./AdminBody.jsx";
+import BASE_URL from "../constants/URL.js";
 
 const Authentication = () => {
 	const [data, setData] = useState([]);
@@ -11,36 +11,41 @@ const Authentication = () => {
 	useEffect(() => {
 		const fetchData = async () => {
 			try {
-				const response = await fetch(`${BASE_URL}/task/01`, {	
-					method: "GET"
+				const response = await fetch(`${BASE_URL}/task/pend/1`, {
+					headers: {
+						"Accept": "application/json",
+						"ngrok-skip-browser-warning": true,
+					},
+					method: "GET",
 				});
 				const res = await response.json();
-				setData(res.task);
+				console.log(res);
+				setData(res.tasks);
 			} catch (error) {
 				console.error(error);
 			}
 		};
 		fetchData();
 	}, []);
-	
+
 	const renderPendings = () => {
 		return (
-			<ul className="text-[20px]">{
-				data.map(
-				(item) =>
-					item.status === "pend" && (
-						<li key={item.id} className="flex hover:text-orange-400">
-							<div className="w-[35%] mr-[1%] whitespace-nowrap overflow-hidden text-ellipsis cursor-pointer">
-								{item.content}
-							</div>
-							<div className="w-[20%]">{item.member_name}</div>
-							<div className="w-[33%]">{item.created_time}</div>
-							<div className="w-[10%] text-center">✅ ❎</div>
-						</li>
-				),
+			<ul className="text-[20px]">
+				{data.map(
+					(item) =>
+						item.status === "pend" && (
+							<li key={item.id} className="flex hover:text-orange-400">
+								<div className="w-[35%] mr-[1%] whitespace-nowrap overflow-hidden text-ellipsis cursor-pointer">
+									{item.content}
+								</div>
+								<div className="w-[20%]">{item.memberName}</div>
+								<div className="w-[33%]">{item.createdTime}</div>
+								<div className="w-[10%] text-center">✅ ❎</div>
+							</li>
+						),
 				)}
 			</ul>
-		)
+		);
 	};
 	// const renderAppeals = () => {
 	// 	return (
@@ -63,7 +68,7 @@ const Authentication = () => {
 
 	return (
 		<AdminBody title={"Authentication"}>
-			<AdminContentBlock title={"Pendings"} contents={renderPendings}/>
+			<AdminContentBlock title={"Pendings"} contents={renderPendings} />
 			{/* <AdminContentBlock title={"Appeals"} contents={renderAppeals}/> */}
 		</AdminBody>
 	);

--- a/millionaire/src/components/DashBoard.jsx
+++ b/millionaire/src/components/DashBoard.jsx
@@ -1,6 +1,6 @@
 export default function DashBoard() {
 	return (
-		<div className="flex-none w-[65%] mt-[20px]">
+		<div className="w-[65%] mt-[20px]">
 			<h1 className="mb-[10px] text-[40px]">Dash Board</h1>
 			<div className="w-[100%] mb-[50px]">
 				<h1 className="text-[25px]">Achievement</h1>
@@ -57,5 +57,5 @@ export default function DashBoard() {
 				</ul>
 			</div>
 		</div>
-	)
+	);
 }

--- a/millionaire/src/components/DashBoard.jsx
+++ b/millionaire/src/components/DashBoard.jsx
@@ -1,61 +1,44 @@
+import { useState } from "react";
+import { useEffect } from "react";
+import AdminContentBlock from "./AdminContentBlock";
+import AdminBody from "./AdminBody";
+
 export default function DashBoard() {
+	const [penalties, setPenalties] = useState([]);
+	useEffect(() => {
+		const fetchData = async () => {
+			try {
+				const response = await fetch("../data/penalty.json", {
+					headers: {
+						"Content-Type": "application/json",
+					},
+				});
+				const res = await response.json();
+				setPenalties(res.members);
+			} catch (error) {
+				console.error(error);
+			}
+		};
+		fetchData();
+	}, []);
+	
+	const renderPenalties = () => {
+		return (
+			<ul className="text-[20px]">{
+				penalties.map(
+				(item) =>(
+				<li key={item.id} className="flex">
+					<div className="w-[50%]">{item.member_name}</div>
+					<div className="w-[30%]">{item.penalty}</div>
+				</li>
+				),
+				)}
+			</ul>
+		)
+	};
 	return (
-		<div className="w-[65%] mt-[20px]">
-			<h1 className="mb-[10px] text-[40px]">Dash Board</h1>
-			<div className="w-[100%] mb-[50px]">
-				<h1 className="text-[25px]">Achievement</h1>
-				<hr className="mb-[5px]"></hr>
-				<ul className="text-[20px]">
-					<li className="flex">
-						<div className="w-[50%]">hyuim</div>
-						<div className="w-[20%]">admin</div>
-						<div className="w-[15%] text-center">23</div>
-						<div className="w-[15%] text-center">40</div>
-					</li>
-					<li className="flex">
-						<div className="w-[50%]">phan</div>
-						<div className="w-[20%]">member</div>
-						<div className="w-[15%] text-center">40</div>
-						<div className="w-[15%] text-center">100</div>
-					</li>
-				</ul>
-			</div>
-			<div className="w-[100%]">
-				<h1 className="text-[25px]">Penalty</h1>
-				<hr className="mb-[5px]"></hr>
-				<ul className="text-[20px]">
-					<li className="flex">
-						<div className="w-[50%]">hyuim</div>
-						<div className="w-[20%]">admin</div>
-						<div className="w-[15%] text-center">3000</div>
-						<div className="w-[15%] text-center">5000</div>
-					</li>
-					<li className="flex">
-						<div className="w-[50%]">soohlee</div>
-						<div className="w-[20%]">manager</div>
-						<div className="w-[15%] text-center">3000</div>
-						<div className="w-[15%] text-center">5000</div>
-					</li>
-					<li className="flex">
-						<div className="w-[50%]">sungmiki</div>
-						<div className="w-[20%]">member</div>
-						<div className="w-[15%] text-center">3000</div>
-						<div className="w-[15%] text-center">5000</div>
-					</li>
-					<li className="flex">
-						<div className="w-[50%]">jonhan</div>
-						<div className="w-[20%]">member</div>
-						<div className="w-[15%] text-center">3000</div>
-						<div className="w-[15%] text-center">5000</div>
-					</li>
-					<li className="flex">
-						<div className="w-[50%]">junssong</div>
-						<div className="w-[20%]">member</div>
-						<div className="w-[15%] text-center">3000</div>
-						<div className="w-[15%] text-center">5000</div>
-					</li>
-				</ul>
-			</div>
-		</div>
+		<AdminBody title={"Dash Board"}>
+			<AdminContentBlock title={"Penalty"} contents={renderPenalties}/>
+		</AdminBody>
 	);
 }

--- a/millionaire/src/components/DashBoard.jsx
+++ b/millionaire/src/components/DashBoard.jsx
@@ -8,13 +8,20 @@ export default function DashBoard() {
 	useEffect(() => {
 		const fetchData = async () => {
 			try {
-				const response = await fetch("../data/penalty.json", {
-					headers: {
-						"Content-Type": "application/json",
-					},
-				});
+				const response = await fetch(`${BASE_URL}/groupmember/penalty`, {
+                    headers: {
+                        "Accept": "application/json",
+                        "ngrok-skip-browser-warning": true,
+                    },
+                    method: "GET",
+					body: {
+						"groupId" : 1,
+						"year": 2024,
+						"month" : 9
+					}
+                });
 				const res = await response.json();
-				setPenalties(res.members);
+				setJoinRequests(res.groupJoinResponses);
 			} catch (error) {
 				console.error(error);
 			}

--- a/millionaire/src/components/DashBoard.jsx
+++ b/millionaire/src/components/DashBoard.jsx
@@ -1,0 +1,61 @@
+export default function DashBoard() {
+	return (
+		<div className="flex-none w-[65%] mt-[20px]">
+			<h1 className="mb-[10px] text-[40px]">Dash Board</h1>
+			<div className="w-[100%] mb-[50px]">
+				<h1 className="text-[25px]">Achievement</h1>
+				<hr className="mb-[5px]"></hr>
+				<ul className="text-[20px]">
+					<li className="flex">
+						<div className="w-[50%]">hyuim</div>
+						<div className="w-[20%]">admin</div>
+						<div className="w-[15%] text-center">23</div>
+						<div className="w-[15%] text-center">40</div>
+					</li>
+					<li className="flex">
+						<div className="w-[50%]">phan</div>
+						<div className="w-[20%]">member</div>
+						<div className="w-[15%] text-center">40</div>
+						<div className="w-[15%] text-center">100</div>
+					</li>
+				</ul>
+			</div>
+			<div className="w-[100%]">
+				<h1 className="text-[25px]">Penalty</h1>
+				<hr className="mb-[5px]"></hr>
+				<ul className="text-[20px]">
+					<li className="flex">
+						<div className="w-[50%]">hyuim</div>
+						<div className="w-[20%]">admin</div>
+						<div className="w-[15%] text-center">3000</div>
+						<div className="w-[15%] text-center">5000</div>
+					</li>
+					<li className="flex">
+						<div className="w-[50%]">soohlee</div>
+						<div className="w-[20%]">manager</div>
+						<div className="w-[15%] text-center">3000</div>
+						<div className="w-[15%] text-center">5000</div>
+					</li>
+					<li className="flex">
+						<div className="w-[50%]">sungmiki</div>
+						<div className="w-[20%]">member</div>
+						<div className="w-[15%] text-center">3000</div>
+						<div className="w-[15%] text-center">5000</div>
+					</li>
+					<li className="flex">
+						<div className="w-[50%]">jonhan</div>
+						<div className="w-[20%]">member</div>
+						<div className="w-[15%] text-center">3000</div>
+						<div className="w-[15%] text-center">5000</div>
+					</li>
+					<li className="flex">
+						<div className="w-[50%]">junssong</div>
+						<div className="w-[20%]">member</div>
+						<div className="w-[15%] text-center">3000</div>
+						<div className="w-[15%] text-center">5000</div>
+					</li>
+				</ul>
+			</div>
+		</div>
+	)
+}

--- a/millionaire/src/components/Li.jsx
+++ b/millionaire/src/components/Li.jsx
@@ -1,0 +1,17 @@
+const Li = (props) => {
+    console.log(props.id);
+    const {item, openModal, id} = props;
+    return (
+        <li className="mt-3 flex hover:text-orange-400 text-[17px]">
+            <div className="w-[43%] mr-[1%] whitespace-nowrap overflow-hidden text-ellipsis cursor-pointer" onClick={()=>openModal(item.taskId, item.content, item.createdTime)}>
+                {item.content}
+            </div>
+            <div className="w-[17%]">{item.memberName}</div>
+            <div className="w-[30%] whitespace-nowrap overflow-hidden text-ellipsis">{item.createdTime}</div>
+            <button className="w-[9%] mr-2 px-1 bg-green-600 hover:bg-green-800 text-white text-[16px] rounded" onClick={()=>props.yes(props.id)}>승인</button>
+            <button className="w-[9%] px-1 bg-red-500 hover:bg-red-700 text-white text-[16px] rounded" onClick={()=>props.no(props.id)}>거절</button>
+        </li>
+    );
+}
+
+export default Li;

--- a/millionaire/src/components/MemberManage.jsx
+++ b/millionaire/src/components/MemberManage.jsx
@@ -1,64 +1,74 @@
+import { useState } from "react";
+import { useEffect } from "react";
+import AdminContentBlock from "./AdminContentBlock";
+import AdminBody from "./AdminBody";
+
 export default function MemberManage() {
+	const [members, setMembers] = useState([]);
+	useEffect(() => {
+		const fetchData = async () => {
+			try {
+				const response = await fetch(BASE_URL);
+				const res = await response.json();
+				setMembers(res.groupmembers);
+			} catch (error) {
+				console.error(error);
+			}
+		};
+		fetchData();
+	}, []);
+	
+	const renderMembers = () => {
+		return (
+			<ul className="text-[20px]">{
+				members.map(
+				(item) =>(
+				<li key={item.id} className="flex hover:text-orange-400">
+					<div className="w-[50%]">{item.member_name}</div>
+					<div className="w-[20%]">{item.grade}</div>
+					<div className="w-[10%] text-center">⬆️</div>
+					<div className="w-[10%] text-center">⬇️</div>
+					<div className="w-[10%] text-center">❌</div>
+				</li>
+				),
+			)}
+			</ul>
+		)
+	};
+
+	const [joinRequests, setJoinRequests] = useState([]);
+	useEffect(() => {
+		const fetchData = async () => {
+			try {
+				const response = await fetch(BASE_URL);
+				const res = await response.json();
+				setJoinRequests(res.joinrequest);
+			} catch (error) {
+				console.error(error);
+			}
+		};
+		fetchData();
+	}, []);
+	
+	const renderJoinRequests = () => {
+		return (
+			<ul className="text-[20px]">
+				{joinRequests.map(
+				(item) =>(
+				<li key={item.id} className="flex hover:text-orange-400">
+					<div className="w-[50%]">{item.member_name}</div>
+					<div className="w-[40%]">{item.created_time}</div>
+					<div className="w-[10%] text-center">✅</div>
+				</li>
+				),
+				)}
+			</ul>
+		)
+	};
 	return (
-		<div className="w-[65%] mt-[20px]">
-			<h1 className="mb-[10px] text-[40px]">Member Management</h1>
-			<div className="mb-[50px] w-[100%]">
-				<h1 className="text-[25px]">Members</h1>
-				<hr className="mb-[5px]"></hr>
-				<ul className="text-[20px]">
-					<li className="flex">
-						<div className="w-[50%]">hyuim</div>
-						<div className="w-[20%]">admin</div>
-						<div className="w-[10%] text-center">⬆️</div>
-						<div className="w-[10%] text-center">⬇️</div>
-						<div className="w-[10%] text-center">❌</div>
-					</li>
-					<li className="flex">
-						<div className="w-[50%]">soohlee</div>
-						<div className="w-[20%]">manager</div>
-						<div className="w-[10%] text-center">⬆️</div>
-						<div className="w-[10%] text-center">⬇️</div>
-						<div className="w-[10%] text-center">❌</div>
-					</li>
-					<li className="flex">
-						<div className="w-[50%]">sungmiki</div>
-						<div className="w-[20%]">member</div>
-						<div className="w-[10%] text-center">⬆️</div>
-						<div className="w-[10%] text-center">⬇️</div>
-						<div className="w-[10%] text-center">❌</div>
-					</li>
-					<li className="flex">
-						<div className="w-[50%]">jonhan</div>
-						<div className="w-[20%]">member</div>
-						<div className="w-[10%] text-center">⬆️</div>
-						<div className="w-[10%] text-center">⬇️</div>
-						<div className="w-[10%] text-center">❌</div>
-					</li>
-					<li className="flex">
-						<div className="w-[50%]">junssong</div>
-						<div className="w-[20%]">member</div>
-						<div className="w-[10%] text-center">⬆️</div>
-						<div className="w-[10%] text-center">⬇️</div>
-						<div className="w-[10%] text-center">❌</div>
-					</li>
-				</ul>
-			</div>
-			<div className="w-[100%]">
-				<h1 className="text-[25px]">Join Request</h1>
-				<hr className="mb-[5px]"></hr>
-				<ul className="text-[20px]">
-					<li className="flex">
-						<div className="w-[50%]">seoson</div>
-						<div className="w-[40%]">2024.09.03 23:02</div>
-						<div className="w-[10%] text-center">✅</div>
-					</li>
-					<li className="flex">
-						<div className="w-[50%]">donglee2</div>
-						<div className="w-[40%]">2024.09.03 23:02</div>
-						<div className="w-[10%] text-center">✅</div>
-					</li>
-				</ul>
-			</div>
-		</div>
+		<AdminBody title={"Member Management"}>
+			<AdminContentBlock title={"Members"} contents={renderMembers}/>
+			<AdminContentBlock title={"Join Request"} contents={renderJoinRequests}/>
+		</AdminBody>
 	);
 }

--- a/millionaire/src/components/MemberManage.jsx
+++ b/millionaire/src/components/MemberManage.jsx
@@ -1,6 +1,6 @@
 export default function MemberManage() {
 	return (
-		<div className="flex-none w-[65%] mt-[20px]">
+		<div className="w-[65%] mt-[20px]">
 			<h1 className="mb-[10px] text-[40px]">Member Management</h1>
 			<div className="mb-[50px] w-[100%]">
 				<h1 className="text-[25px]">Members</h1>
@@ -60,5 +60,5 @@ export default function MemberManage() {
 				</ul>
 			</div>
 		</div>
-	)
+	);
 }

--- a/millionaire/src/components/MemberManage.jsx
+++ b/millionaire/src/components/MemberManage.jsx
@@ -1,34 +1,90 @@
-import { useState } from "react";
-import { useEffect } from "react";
+import { useState, useEffect } from "react";
 import AdminContentBlock from "./AdminContentBlock";
 import AdminBody from "./AdminBody";
+import BASE_URL from "../constants/URL.js";
 
 export default function MemberManage() {
 	const [members, setMembers] = useState([]);
+	const [joinRequests, setJoinRequests] = useState([]);
+
+	const fetchMembers = async () => {
+		try {
+			const response = await fetch(`${BASE_URL}/groupmember/1`, {
+				headers: {
+					"Accept": "application/json",
+					"ngrok-skip-browser-warning": true,
+				},
+				method: "GET",
+			});
+			const res = await response.json();
+			setMembers(res.groupMembers);
+		} catch (error) {
+			console.error(error);
+		}
+	};
+
 	useEffect(() => {
-		const fetchData = async () => {
-			try {
-				const response = await fetch(BASE_URL);
-				const res = await response.json();
-				setMembers(res.groupmembers);
-			} catch (error) {
-				console.error(error);
-			}
-		};
-		fetchData();
+		fetchMembers();
 	}, []);
-	
+
+	const gradeChange = async (memberId, status) => {
+		try {
+            const response = await fetch(`${BASE_URL}/groupmember`, {
+                headers: {
+                    "Accept": "application/json",
+					"Content-Type": "application/json",
+                    "ngrok-skip-browser-warning": true,
+                },
+                method: "PATCH",
+				body:JSON.stringify({
+					"groupId" : 1,
+					"memberId" : memberId,
+					"role" : status
+				}),
+            });
+            console.log(response);
+			if (response.ok){
+				await fetchMembers();
+			}
+        } catch (error) {
+            console.error(error);
+        }
+	}
+
+	const memberDelete = (memberId) => {
+		try {
+            const response = fetch(`${BASE_URL}/groupmember`, {
+                headers: {
+                    "Accept": "application/json",
+					"Content-Type": "application/json",
+                    "ngrok-skip-browser-warning": true,
+                },
+                method: "DELETE",
+				body:JSON.stringify({
+					"groupId" : 1,
+					"memberId" : memberId,
+				}),
+            });
+            console.log(response);
+			if (response.status === 200){
+				setMembers();
+			}
+        } catch (error) {
+            console.error(error);
+        }
+	}
+
 	const renderMembers = () => {
 		return (
 			<ul className="text-[20px]">{
 				members.map(
 				(item) =>(
 				<li key={item.id} className="flex hover:text-orange-400">
-					<div className="w-[50%]">{item.member_name}</div>
+					<div className="w-[50%]">{item.name}</div>
 					<div className="w-[20%]">{item.grade}</div>
-					<div className="w-[10%] text-center">⬆️</div>
-					<div className="w-[10%] text-center">⬇️</div>
-					<div className="w-[10%] text-center">❌</div>
+					<button className="w-[9%] mr-2 px-1 bg-green-600 hover:bg-green-800 text-white text-[16px] rounded" onClick={()=>{gradeChange(item.memberId, "up")}}>승급</button>
+					<button className="w-[9%] mr-2 px-1 bg-green-600 hover:bg-green-800 text-white text-[16px] rounded" onClick={()=>{gradeChange(item.memberId, "down")}}>강등</button>
+            		<button className="w-[9%] px-1 bg-red-500 hover:bg-red-700 text-white text-[16px] rounded" onClick={()=>{memberDelete(item.memberId)}}>탈퇴</button>
 				</li>
 				),
 			)}
@@ -36,13 +92,18 @@ export default function MemberManage() {
 		)
 	};
 
-	const [joinRequests, setJoinRequests] = useState([]);
 	useEffect(() => {
 		const fetchData = async () => {
 			try {
-				const response = await fetch(BASE_URL);
+				const response = await fetch(`${BASE_URL}/groupjoin/1`, {
+                    headers: {
+                        "Accept": "application/json",
+                        "ngrok-skip-browser-warning": true,
+                    },
+                    method: "GET",
+                });
 				const res = await response.json();
-				setJoinRequests(res.joinrequest);
+				setJoinRequests(res.groupJoinResponses);
 			} catch (error) {
 				console.error(error);
 			}
@@ -56,8 +117,8 @@ export default function MemberManage() {
 				{joinRequests.map(
 				(item) =>(
 				<li key={item.id} className="flex hover:text-orange-400">
-					<div className="w-[50%]">{item.member_name}</div>
-					<div className="w-[40%]">{item.created_time}</div>
+					<div className="w-[50%]">{item.name}</div>
+					<div className="w-[40%]">{item.createdTime}</div>
 					<div className="w-[10%] text-center">✅</div>
 				</li>
 				),

--- a/millionaire/src/components/MemberManage.jsx
+++ b/millionaire/src/components/MemberManage.jsx
@@ -1,0 +1,64 @@
+export default function MemberManage() {
+	return (
+		<div className="flex-none w-[65%] mt-[20px]">
+			<h1 className="mb-[10px] text-[40px]">Member Management</h1>
+			<div className="mb-[50px] w-[100%]">
+				<h1 className="text-[25px]">Members</h1>
+				<hr className="mb-[5px]"></hr>
+				<ul className="text-[20px]">
+					<li className="flex">
+						<div className="w-[50%]">hyuim</div>
+						<div className="w-[20%]">admin</div>
+						<div className="w-[10%] text-center">⬆️</div>
+						<div className="w-[10%] text-center">⬇️</div>
+						<div className="w-[10%] text-center">❌</div>
+					</li>
+					<li className="flex">
+						<div className="w-[50%]">soohlee</div>
+						<div className="w-[20%]">manager</div>
+						<div className="w-[10%] text-center">⬆️</div>
+						<div className="w-[10%] text-center">⬇️</div>
+						<div className="w-[10%] text-center">❌</div>
+					</li>
+					<li className="flex">
+						<div className="w-[50%]">sungmiki</div>
+						<div className="w-[20%]">member</div>
+						<div className="w-[10%] text-center">⬆️</div>
+						<div className="w-[10%] text-center">⬇️</div>
+						<div className="w-[10%] text-center">❌</div>
+					</li>
+					<li className="flex">
+						<div className="w-[50%]">jonhan</div>
+						<div className="w-[20%]">member</div>
+						<div className="w-[10%] text-center">⬆️</div>
+						<div className="w-[10%] text-center">⬇️</div>
+						<div className="w-[10%] text-center">❌</div>
+					</li>
+					<li className="flex">
+						<div className="w-[50%]">junssong</div>
+						<div className="w-[20%]">member</div>
+						<div className="w-[10%] text-center">⬆️</div>
+						<div className="w-[10%] text-center">⬇️</div>
+						<div className="w-[10%] text-center">❌</div>
+					</li>
+				</ul>
+			</div>
+			<div className="w-[100%]">
+				<h1 className="text-[25px]">Join Request</h1>
+				<hr className="mb-[5px]"></hr>
+				<ul className="text-[20px]">
+					<li className="flex">
+						<div className="w-[50%]">seoson</div>
+						<div className="w-[40%]">2024.09.03 23:02</div>
+						<div className="w-[10%] text-center">✅</div>
+					</li>
+					<li className="flex">
+						<div className="w-[50%]">donglee2</div>
+						<div className="w-[40%]">2024.09.03 23:02</div>
+						<div className="w-[10%] text-center">✅</div>
+					</li>
+				</ul>
+			</div>
+		</div>
+	)
+}

--- a/millionaire/src/components/Modal.jsx
+++ b/millionaire/src/components/Modal.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+const Modal = ({ isOpen, onClose, children }) => {
+    // console.log(children);
+    if (!isOpen) return null;
+
+    return (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center">
+            <div className="bg-white p-5 rounded shadow-lg w-[70%]">
+                <div>
+                    {children}
+                </div>
+                <button className="mt-4 bg-red-500 text-white px-4 py-2 rounded" onClick={onClose}>
+                    Close
+                </button>
+            </div>
+        </div>
+    );
+};
+
+export default Modal;

--- a/millionaire/src/components/Notice.jsx
+++ b/millionaire/src/components/Notice.jsx
@@ -1,16 +1,48 @@
-import { useState } from "react";
+import { Fragment, useState, useEffect } from "react";
 import AdminContentBlock from "./AdminContentBlock";
 import AdminBody from "./AdminBody";
+import { getAPI } from "../apis/get.js";
+import BASE_URL from "../constants/URL.js";
 
 export default function DashBoard() {
 	const [noticeContent, setNoticeContent] = useState("");
+
+	useEffect(() => {
+		fetchNotice();
+	}, []);
+	
+	const fetchNotice = async () => {
+		try {
+			const data = await getAPI('group/notice/1');
+			console.log(data);
+			setNoticeContent(data.notice);
+		} catch (error) {
+			console.error(error);
+		}
+	};
 	const handleClick = () => {
-		console.log("HELLO");
+		try {
+            const response = fetch(`${BASE_URL}/group/notice`, {
+                headers: {
+                    "Accept": "application/json",
+					"Content-Type": "application/json",
+                    "ngrok-skip-browser-warning": true,
+                },
+                method: "POST",
+				body:JSON.stringify({
+					"groupId" : 1,
+					"notice" : noticeContent
+				}),
+            });
+            console.log(response);
+        } catch (error) {
+            console.error(error);
+        }
 	};
 
 	const noticeBox = () =>{
 		return (
-			<>
+			<Fragment>
 			<p>
 				<textarea
 					className="w-[100%] h-[300px] bg-black"
@@ -30,12 +62,12 @@ export default function DashBoard() {
 					Notify
 				</button>
 			</div>
-			</>
+			</Fragment>
 		)
 	}
 	return (
 		<AdminBody title={"Notice Board"}>
-			<AdminContentBlock className={"w-[80%]"} title={"Notice"} contents={noticeBox}/>
+			<AdminContentBlock className={"w-[90%]"} title={"Notice"} contents={noticeBox}/>
 		</AdminBody>
 	);
 }

--- a/millionaire/src/components/Notice.jsx
+++ b/millionaire/src/components/Notice.jsx
@@ -1,0 +1,13 @@
+export default function DashBoard() {
+	return (
+		<div className="flex-none w-[65%] mt-[20px]">
+			<h1 className="mb-[10px] text-[40px]">Notice Board</h1>
+			<div className="w-[100%] mb-[50px]">
+				<h1 className="text-[25px]">Notice</h1>
+				<hr className="mb-[5px]"></hr>
+       			<p><textarea className="w-[100%] h-[300px] bg-black" name="notice" placeholder='Notice'></textarea></p>
+        		<p className="flex justify-end"><input className="self-end" type="submit" value="Notify"/></p>
+			</div>
+		</div>
+	)
+}

--- a/millionaire/src/components/Notice.jsx
+++ b/millionaire/src/components/Notice.jsx
@@ -1,36 +1,41 @@
 import { useState } from "react";
+import AdminContentBlock from "./AdminContentBlock";
+import AdminBody from "./AdminBody";
 
 export default function DashBoard() {
 	const [noticeContent, setNoticeContent] = useState("");
 	const handleClick = () => {
 		console.log("HELLO");
 	};
-	return (
-		<div className="w-[55%] mt-[20px]">
-			<h1 className="mb-[10px] text-[40px]">Notice Board</h1>
-			<div className="w-[100%] mb-[50px]">
-				<h1 className="text-[25px]">Notice</h1>
-				<hr className="mb-[5px]" />
-				<p>
-					<textarea
-						className="w-[100%] h-[300px] bg-black"
-						name="notice"
-						placeholder="Notice"
-						value={noticeContent}
-						maxLength={300}
-						onChange={(e) => setNoticeContent(e.target.value)}
+
+	const noticeBox = () =>{
+		return (
+			<>
+			<p>
+				<textarea
+					className="w-[100%] h-[300px] bg-black"
+					name="notice"
+					placeholder="Notice"
+					value={noticeContent}
+					maxLength={300}
+					onChange={(e) => setNoticeContent(e.target.value)}
 					/>
-				</p>
-				<div className="flex justify-end items-center mt-2">
-					<span className="mr-4">{noticeContent.length} / 300</span>
-					<button
-						className="border-[2px] rounded-[10px] px-4 py-1 text-sm"
-						onClick={handleClick}
+			</p>
+			<div className="flex justify-end items-center mt-2">
+				<span className="mr-4">{noticeContent.length} / 300</span>
+				<button
+					className="border-[2px] rounded-[10px] px-4 py-1 text-sm"
+					onClick={handleClick}
 					>
-						Notify
-					</button>
-				</div>
+					Notify
+				</button>
 			</div>
-		</div>
+			</>
+		)
+	}
+	return (
+		<AdminBody title={"Notice Board"}>
+			<AdminContentBlock className={"w-[80%]"} title={"Notice"} contents={noticeBox}/>
+		</AdminBody>
 	);
 }

--- a/millionaire/src/components/Notice.jsx
+++ b/millionaire/src/components/Notice.jsx
@@ -1,13 +1,36 @@
+import { useState } from "react";
+
 export default function DashBoard() {
+	const [noticeContent, setNoticeContent] = useState("");
+	const handleClick = () => {
+		console.log("HELLO");
+	};
 	return (
-		<div className="flex-none w-[65%] mt-[20px]">
+		<div className="w-[55%] mt-[20px]">
 			<h1 className="mb-[10px] text-[40px]">Notice Board</h1>
 			<div className="w-[100%] mb-[50px]">
 				<h1 className="text-[25px]">Notice</h1>
-				<hr className="mb-[5px]"></hr>
-       			<p><textarea className="w-[100%] h-[300px] bg-black" name="notice" placeholder='Notice'></textarea></p>
-        		<p className="flex justify-end"><input className="self-end" type="submit" value="Notify"/></p>
+				<hr className="mb-[5px]" />
+				<p>
+					<textarea
+						className="w-[100%] h-[300px] bg-black"
+						name="notice"
+						placeholder="Notice"
+						value={noticeContent}
+						maxLength={300}
+						onChange={(e) => setNoticeContent(e.target.value)}
+					/>
+				</p>
+				<div className="flex justify-end items-center mt-2">
+					<span className="mr-4">{noticeContent.length} / 300</span>
+					<button
+						className="border-[2px] rounded-[10px] px-4 py-1 text-sm"
+						onClick={handleClick}
+					>
+						Notify
+					</button>
+				</div>
 			</div>
 		</div>
-	)
+	);
 }

--- a/millionaire/src/components/PendingModalContent.jsx
+++ b/millionaire/src/components/PendingModalContent.jsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from "react";
+
+const PendingModalContent = (id, title) => {
+    const [data, setData] = useState([]);
+
+	useEffect(() => {
+		const fetchData = async () => {
+			try {
+				const response = await fetch(`${BASE_URL}/verification/${id}`, {
+					headers: {
+						"Accept": "application/json",
+						"ngrok-skip-browser-warning": true,
+					},
+					method: "GET",
+				});
+				const res = await response.json();
+				console.log(res);
+				setData(res);
+			} catch (error) {
+				console.error(error);
+			}
+		};
+		fetchData();
+	}, []);
+    return (
+        <div>
+            <h3>{title}</h3>
+            <div>{data.createTime}</div>
+            <div>{data.updateTime}</div>
+            <hr></hr>
+            <div className="">
+                <div>{data.content}</div>
+                {data.base64_images.map(
+					(item) =>(
+						<image src={item}/>
+					),
+				)}
+            </div>
+        </div>
+    )
+}
+
+
+export default PendingModalContent;

--- a/millionaire/src/components/Sidebar.jsx
+++ b/millionaire/src/components/Sidebar.jsx
@@ -2,14 +2,15 @@ import PAGE_TITLES from "../constants/PAGE_TITLES";
 
 const Sidebar = ({ setPage }) => (
 	<div className="w-[23%] mt-[20px] ml-[20px]">
-		<h1 className="mb-[50px] text-[36px]">세후1억 해적단</h1>
+		<h1 className="mb-[50px] mt-[20px] text-[30px]">☠️세후1억 해적단☠️</h1>
 		<nav>
 			<ul className="text-[20px]">
 				{Object.entries(PAGE_TITLES).map(([key, title]) => (
-					<li key={key} onClick={() => setPage(key)}>
+					<li key={key} onClick={() => setPage(key)} className="hover:text-orange-400 cursor-pointer  w-fit">
 						{title}
 					</li>
 				))}
+				<a href="/" className="hover:text-orange-400">Admin out</a>
 			</ul>
 		</nav>
 	</div>

--- a/millionaire/src/components/Sidebar.jsx
+++ b/millionaire/src/components/Sidebar.jsx
@@ -1,0 +1,18 @@
+import PAGE_TITLES from "../constants/PAGE_TITLES";
+
+const Sidebar = ({ setPage }) => (
+	<div className="w-[23%] mt-[20px] ml-[20px]">
+		<h1 className="mb-[50px] text-[36px]">세후1억 해적단</h1>
+		<nav>
+			<ul className="text-[20px]">
+				{Object.entries(PAGE_TITLES).map(([key, title]) => (
+					<li key={key} onClick={() => setPage(key)}>
+						{title}
+					</li>
+				))}
+			</ul>
+		</nav>
+	</div>
+);
+
+export default Sidebar;

--- a/millionaire/src/components/Sidebar.jsx
+++ b/millionaire/src/components/Sidebar.jsx
@@ -1,12 +1,12 @@
-import PAGE_TITLES from "../constants/PAGE_TITLES";
+import PAGE_TITLES from "../constants/PAGE_TITLES.js";
 
 const Sidebar = ({ setPage }) => (
-	<div className="w-[23%] mt-[20px] ml-[20px]">
+	<div className="w-[23%] mt-[20px] ml-[20px] mr-[10px]">
 		<h1 className="mb-[50px] mt-[20px] text-[30px]">☠️세후1억 해적단☠️</h1>
 		<nav>
 			<ul className="text-[20px]">
 				{Object.entries(PAGE_TITLES).map(([key, title]) => (
-					<li key={key} onClick={() => setPage(key)} className="hover:text-orange-400 cursor-pointer  w-fit">
+					<li key={key} onClick={() => setPage(key)} className="mb-[20px] hover:text-orange-400 cursor-pointer  w-fit">
 						{title}
 					</li>
 				))}

--- a/millionaire/src/constants/PAGE_TITLES.js
+++ b/millionaire/src/constants/PAGE_TITLES.js
@@ -1,0 +1,8 @@
+const PAGE_TITLES = {
+	AUTH: "Authentication",
+	MEMBER: "Member Management",
+	DASH: "Dash Board",
+	NOTICE: "Notice Board",
+};
+
+export default PAGE_TITLES;

--- a/millionaire/src/constants/URL.js
+++ b/millionaire/src/constants/URL.js
@@ -1,3 +1,3 @@
-const BASE_URL=`https://ef1b-121-135-181-35.ngrok-free.app`;
+const BASE_URL = `https://4694-121-135-181-35.ngrok-free.app`;
 
 export default BASE_URL;

--- a/millionaire/src/constants/URL.js
+++ b/millionaire/src/constants/URL.js
@@ -1,3 +1,3 @@
-const BASE_URL = `https://4694-121-135-181-35.ngrok-free.app`;
+const BASE_URL = `https://6447-121-135-181-35.ngrok-free.app`;
 
 export default BASE_URL;

--- a/millionaire/src/constants/URL.js
+++ b/millionaire/src/constants/URL.js
@@ -1,0 +1,3 @@
+const BASE_URL=`https://ef1b-121-135-181-35.ngrok-free.app`;
+
+export default BASE_URL;

--- a/millionaire/src/index.css
+++ b/millionaire/src/index.css
@@ -3,5 +3,5 @@
 @tailwind utilities;
 
 body{
-    background-color: rgb(18, 18, 17);
+    background-color: rgb(118, 115, 115);
 }

--- a/millionaire/src/index.css
+++ b/millionaire/src/index.css
@@ -1,3 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body{
+    background-color: rgb(18, 18, 17);
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

**> 관리자 페이지 완성**

**관리자 메뉴 (사이드바)**
- **Authentication:** 인증대기 & 이의제기
- **Member Management**: 멤버현황 & 가입요청현황
- **Dash Board:** 벌금현황 조회
- **Notice Board:** 공지사항 확인 및 수정
- **Admin out:** 관리자페이지 나가기 (메인페이지로 링크)

**전체적인 컴포넌트 관리**
사이드바 메뉴 하나씩 컴포넌트로 관리. 
각 컨포넌트는 <AdminBody/> 컴포넌트 로 관리하고, 
각 항목별로, <AdminContentBlock/> 컴포넌트로 관리.
세부사항은 <Li/> 컴포넌트로 한줄씩 출력

**각 버튼 활성화**
승인, 거절, 승급, 강등, 탈퇴 버튼 기능별 함수 구현

**공지사항**
이전 공지사항을 먼저 띄우고 수정할 수 있게 구현

**Task 클릭시 세부사항 보기**
인증 대기와, 이의제기는 제목을 클릭시 세부사항을 볼수 있도록 구현
Modal 컴포넌트로 관리.  

### 스크린샷 (선택)
<img width="1108" alt="PR참고" src="https://github.com/user-attachments/assets/704005e8-939e-499c-91dd-46c7122095fc">

## 💬리뷰 요구사항(선택)

컴포넌트의 이름들이 적절한지 확신이 없습니다.
각 버튼이 컨포넌트화가 안되어 있는데 컴포넌트화가 필요할까요?